### PR TITLE
Fix NIAttributedLabel highlightedTextColor incorrectly override linkColor when highlighted.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1346,6 +1346,12 @@ _NI_UIACTIONSHEET_DEPRECATION_SUPPRESSION_POP()
 // style information.
 - (NSMutableAttributedString *)mutableAttributedStringWithAdditions {
   NSMutableAttributedString* attributedString = [self.mutableAttributedString mutableCopy];
+  
+  // Set highlighted text color for the entire string first to avoid undesired style override e.g., link color.
+  if (self.isHighlighted) {
+    [attributedString setTextColor:self.highlightedTextColor];
+  }
+
   if (self.autoDetectLinks) {
     [self _applyLinkStyleWithResults:self.detectedlinkLocations
                   toAttributedString:attributedString];
@@ -1416,10 +1422,6 @@ _NI_UIACTIONSHEET_DEPRECATION_SUPPRESSION_POP()
         [attributedString insertAttributedString:space atIndex:labelImage.index];
       }
     }
-  }
-
-  if (self.isHighlighted) {
-    [attributedString setTextColor:self.highlightedTextColor];
   }
 
   return attributedString;


### PR DESCRIPTION
Update NIAttributedLabel highlightedTextColor first so as not to incorrectly overrides other styling like linkColor.